### PR TITLE
Fix certificate related things

### DIFF
--- a/iDealAdvancedConnector/Connector.cs
+++ b/iDealAdvancedConnector/Connector.cs
@@ -392,15 +392,6 @@ namespace iDealAdvancedConnector
 
             try
             {
-                #if RUNNING_ON_4_5
-                // Bypass service certificate validation
-                var disableAcquirerSSLCertificateValidation = GetOptionalAppSetting("DisableAcquirerSSLCertificateValidation", "False");
-                if (disableAcquirerSSLCertificateValidation.ToLowerInvariant().Equals("true"))
-                {
-                    httpWebRequest.ServerCertificateValidationCallback += DisableAcquirerSSLCertificateValidation;
-                }                            
-                #endif
-
                 _httpClient.Timeout = TimeSpan.FromSeconds(merchantConfig.acquirerTimeout);
 
                 var response = await _httpClient.PostAsync(url, new StringContent(request, Encoding.UTF8, "text/xml"));
@@ -418,16 +409,6 @@ namespace iDealAdvancedConnector
             if (traceSwitch.TraceVerbose) TraceLine(Format("Returnvalue: {0}", deserializedResponse));
             return deserializedResponse;
         }
-
-#if RUNNING_ON_4_5
-        /// <summary>
-        /// Disables the the acquirer's certificate validation
-        /// </summary>
-        private static bool DisableAcquirerSSLCertificateValidation(object sender, X509Certificate cert, X509Chain chain, System.Net.Security.SslPolicyErrors error)
-        {
-            return true;
-        }
-#endif
 
         /// <summary>
         /// Creates a Merchant object.

--- a/iDealAdvancedConnector/Connector.cs
+++ b/iDealAdvancedConnector/Connector.cs
@@ -395,7 +395,7 @@ namespace iDealAdvancedConnector
                 _httpClient.Timeout = TimeSpan.FromSeconds(merchantConfig.acquirerTimeout);
 
                 var response = await _httpClient.PostAsync(url, new StringContent(request, Encoding.UTF8, "text/xml"));
-                deserializedResponse = response.Content.ReadAsStringAsync().Result;
+                deserializedResponse = await response.Content.ReadAsStringAsync();
             }
             catch (Exception e)
             {

--- a/iDealAdvancedConnector/Connector.cs
+++ b/iDealAdvancedConnector/Connector.cs
@@ -402,7 +402,8 @@ namespace iDealAdvancedConnector
                 #endif
 
                 _httpClient.Timeout = TimeSpan.FromSeconds(merchantConfig.acquirerTimeout);
-                var response = await _httpClient.PostAsync(url, new StringContent(request, Encoding.UTF8, "text/xml; charset=\"{0}\""));
+
+                var response = await _httpClient.PostAsync(url, new StringContent(request, Encoding.UTF8, "text/xml"));
                 deserializedResponse = response.Content.ReadAsStringAsync().Result;
             }
             catch (Exception e)

--- a/iDealAdvancedConnector/README.md
+++ b/iDealAdvancedConnector/README.md
@@ -1,0 +1,13 @@
+# Certificate configuration
+
+- `ideal_v3.cer` is the `AcquirerCertificate` and is not password protected. To convert into a form suitable to put into `appsettings.json`, remove the lines "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----" and any line breaks and whitespaces.
+
+- A file called `*.p12` is the `ClientCertificate`, most likely including the private key used to sign the messages. Convert the file as is to base64 encoding using the following command:
+
+```bash
+    openssl base64 -in  CkoIdeal.p12 -out CkoIdeal.p12.base64
+```
+
+and remove any line breaks and whitespaces. Use the resulting string as value for `ClientCertificate`.
+
+- Since your `*.p12` file contains your private key it is most likely password protected. Use `ClientCertificatePassword` to specify the password to be used when loading the certificate.

--- a/iDealAdvancedConnector/Security/XsdValidation.cs
+++ b/iDealAdvancedConnector/Security/XsdValidation.cs
@@ -18,7 +18,7 @@ namespace iDealAdvancedConnector.Security
     class XsdValidation
     {
         static XmlSchemaSet allSchemas;
-        static readonly String Namespace = "ING.iDealAdvanced.Messages.";
+        static readonly String Namespace = "iDealAdvancedConnector.Messages.";
 
         /// <summary>
         /// Static ctor

--- a/iDealAdvancedConnector/iDealAdvancedConnector.csproj
+++ b/iDealAdvancedConnector/iDealAdvancedConnector.csproj
@@ -5,4 +5,8 @@
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.5.0" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Messages\itt-acq.xsd" />
+    <EmbeddedResource Include="Messages\xmldsigcore-schema.xsd" />
+</ItemGroup>
 </Project>

--- a/iDealAdvancedConnector/iDealConnectorOptions.cs
+++ b/iDealAdvancedConnector/iDealConnectorOptions.cs
@@ -2,7 +2,22 @@
 {
     public class IDealConnectorOptions
     {
+        /// <summary>
+        /// Base64 encoded string of the ClientCertificate
+        /// </summary>
+        /// <value></value>
         public string ClientCertificate { get; set; }
+
+        /// <summary>
+        /// Password used to protected the ClientCertificate (if applicable)
+        /// </summary>
+        /// <value></value>
+        public string ClientCertificatePassword { get; set; }
+        
+        /// <summary>
+        /// Base64 encoded string of the AcquirerCertificate
+        /// </summary>
+        /// <value></value>
         public string AcquirerCertificate { get; set; }
         public string AcquirerTimeout { get; set; }
         public string MerchantId { get; set; }
@@ -13,7 +28,5 @@
         public string AcquirerDirectoryURL { get; set; }
         public string AcquirerTransactionURL { get; set; }
         public string AcquirerTransactionStatusURL { get; set; }
-        public string UseCspMachineKeyStore { get; set; }
-        public string UseCertificateWithEnhancedAESCryptoProvider { get; set; }
     }
 }

--- a/iDealSampleConsole/Program.cs
+++ b/iDealSampleConsole/Program.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using System.Xml;
 using iDealAdvancedConnector;
 using iDealAdvancedConnector.Security;
@@ -12,22 +14,25 @@ namespace iDealSampleConsole
 {
     public class Program
     {
-        private static void Main(string[] args)
+        private static async Task Main(string[] args)
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile("appsettings.local.json", optional: true, reloadOnChange: true);
 
             var configuration = builder.Build();
             var idealConnectorOptions = new IDealConnectorOptions();
             configuration.GetSection("IDealConnector").Bind(idealConnectorOptions);
-            Test(idealConnectorOptions);
+            //Test(idealConnectorOptions);
+            
+            await GetIssuers(idealConnectorOptions);
         }
+        
+
 
         private static void Test(IDealConnectorOptions idealConnectorOptions)
         {
-            Console.WriteLine("Press enter to start the test");
-            Console.ReadLine();
             CryptoConfig.AddAlgorithm(typeof(RSAPKCS1SHA256SignatureDescription), "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
 
             // Create a new XML document and format to ignore white space
@@ -40,14 +45,29 @@ namespace iDealSampleConsole
             var connector = new Connector(new HttpClient(), idealConnectorOptions);
 
             var certificate = connector.ClientCertificate;
-            XmlSignature.Sign(ref doc, null, certificate.Thumbprint);
+            XmlSignature.Sign(ref doc, (RSA)certificate.PrivateKey, certificate.Thumbprint);
 
             Console.WriteLine(doc.OuterXml);
             Console.WriteLine("");
             Console.WriteLine("");
             Console.WriteLine("");
             Console.WriteLine("Ended");
-            Console.ReadLine();
+            
+        }
+
+        private static async Task GetIssuers(IDealConnectorOptions idealConnectorOptions)
+        {
+            var connector = new Connector(new HttpClient(), idealConnectorOptions);
+            var issuers = await connector.GetIssuerList();
+            
+            foreach(var country in issuers.Countries)
+            {
+                Console.WriteLine(country.CountryNames);
+                foreach(var issuer in country.Issuers)
+                {
+                    Console.WriteLine(issuer.Name);
+                }
+            }
         }
     }
 }

--- a/iDealSampleConsole/appsettings.json
+++ b/iDealSampleConsole/appsettings.json
@@ -8,10 +8,8 @@
     "ClientCertificate": "Maxcode",
     "SubId": "0",
     "AcquirerURL": "",
-    "AcquirerDirectoryURL": "https://itt.maxcode.ro/ITTEmulatorAcquirer/Directory.aspx",
-    "AcquirerTransactionURL": "https://itt.maxcode.ro/ITTEmulatorAcquirer/Transaction.aspx",
-    "AcquirerTransactionStatusURL": "https://itt.maxcode.ro/ITTEmulatorAcquirer/Status.aspx",
-    "UseCspMachineKeyStore": "false",
-    "UseCertificateWithEnhancedAESCryptoProvider": "false" 
+    "AcquirerDirectoryURL": "",
+    "AcquirerTransactionURL": "",
+    "AcquirerTransactionStatusURL": ""
   }
 }

--- a/iDealSampleConsole/iDealSampleConsole.csproj
+++ b/iDealSampleConsole/iDealSampleConsole.csproj
@@ -5,6 +5,10 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />


### PR DESCRIPTION
Connector:

- Remove .NET 4.5/Windows specific certificate handling code, which also simplifies configuration
- Fix XsdValidation
- Remove charset from mediatype since it doesn't seem to be supported here
- Remove #if RUNNING_ON_4_5 - won't happen

iDealSampleConsole:

- Add GetIssuer() example
- make it use async main
- add appsettings.local.json reading
- remove no longer necessary appsettings