### PR TITLE
Setting the timeout on the HttpClient in here makes it impossible for…

### DIFF
--- a/src/iDealAdvancedConnector/Connector.cs
+++ b/src/iDealAdvancedConnector/Connector.cs
@@ -390,8 +390,6 @@ namespace iDealAdvancedConnector
 
             try
             {
-                _httpClient.Timeout = TimeSpan.FromSeconds(merchantConfig.acquirerTimeout);
-
                 var response = await _httpClient.PostAsync(url, new StringContent(request, Encoding.UTF8, "text/xml"));
                 deserializedResponse = await response.Content.ReadAsStringAsync();
             }

--- a/src/iDealAdvancedConnector/MerchantConfig.cs
+++ b/src/iDealAdvancedConnector/MerchantConfig.cs
@@ -62,11 +62,6 @@ namespace iDealAdvancedConnector
         public Uri acquirerUrlSTA;
 
         /// <summary>
-        /// The acquirer timeout
-        /// </summary>
-        public int acquirerTimeout;
-
-        /// <summary>
         /// The currency
         /// </summary>
         public string currency;
@@ -130,10 +125,6 @@ namespace iDealAdvancedConnector
                 if (!Uri.TryCreate(acquirerTransactionUrl, UriKind.Absolute, out newMerchant.acquirerUrlTRA)) throw new UriFormatException("AcquirerTransactionURL is not in correct format.");
                 if (!Uri.TryCreate(acquirerTransactionStatusUrl, UriKind.Absolute, out newMerchant.acquirerUrlSTA)) throw new UriFormatException("AcquirerTransactionStatusURL is not in correct format.");
             }
-
-            string acquirerTimeout = idealConnectorOptions.AcquirerTimeout;
-            if (!Int32.TryParse(acquirerTimeout, out newMerchant.acquirerTimeout))
-                throw new InvalidCastException("AcquirerTimeout is not in correct format.");
 
             newMerchant.ExpirationPeriod = !string.IsNullOrWhiteSpace(idealConnectorOptions.ExpirationPeriod)
                     ? idealConnectorOptions.ExpirationPeriod

--- a/src/iDealAdvancedConnector/iDealConnectorOptions.cs
+++ b/src/iDealAdvancedConnector/iDealConnectorOptions.cs
@@ -21,7 +21,8 @@
         public string AcquirerCertificate { get; set; }
 
         /// <summary>
-        /// Acquirer timeout in seconds
+        /// Acquirer timeout in seconds. Note that this isn't handled automatically by this library
+        /// A user of the connector has to configure the passed in HttpClient with that value himself
         /// </summary>
         /// <value></value>
         public string AcquirerTimeout { get; set; }

--- a/src/iDealAdvancedConnector/iDealConnectorOptions.cs
+++ b/src/iDealAdvancedConnector/iDealConnectorOptions.cs
@@ -19,6 +19,11 @@
         /// </summary>
         /// <value></value>
         public string AcquirerCertificate { get; set; }
+
+        /// <summary>
+        /// Acquirer timeout in seconds
+        /// </summary>
+        /// <value></value>
         public string AcquirerTimeout { get; set; }
         public string MerchantId { get; set; }
         public string SubId { get; set; }


### PR DESCRIPTION
… us to retry certain requests due to this exception: System.InvalidOperationException: This instance has already started one or more requests. Properties can only be modified before sending the first request.