### PR TITLE
Lock serializers on add

### DIFF
--- a/src/iDealAdvancedConnector/SerializationHelper.cs
+++ b/src/iDealAdvancedConnector/SerializationHelper.cs
@@ -79,15 +79,20 @@ namespace iDealAdvancedConnector
         /// <returns>Xml Serializer for the object type.</returns>
         private static XmlSerializer GetSerializer<T>()
         {
-            XmlSerializer serializer = serializers[typeof(T).Name] as XmlSerializer;
+            return serializers[typeof(T).Name] as XmlSerializer ?? CreateAndRegisterSerializer<T>();
+        }
 
-            if (serializer == null)
+        private static XmlSerializer CreateAndRegisterSerializer<T>()
+        {
+            lock (thisLock)
             {
-                serializer = new XmlSerializer(typeof(T));
-                serializers.Add(typeof(T).Name, serializer);
+                if (!serializers.ContainsKey(typeof(T).Name))
+                {
+                    serializers.Add(typeof(T).Name, new XmlSerializer(typeof(T)));
+                }
             }
-            return serializer;
 
+            return (XmlSerializer)serializers[typeof(T).Name];
         }
 
 


### PR DESCRIPTION
`serializers` is a static property which is populated the first time a particular type is serialized. In case of multiple requests in parallel, this may produce an exception when adding the same serializer multiple times.

Added a lock around `serializers` (the same lock is already used during inititialization of `serializers`), which should only be relevant during first requests.