### PR TITLE
Bug/fix concurrent use of xmlschemaset

### DIFF
--- a/src/iDealAdvancedConnector/Connector.cs
+++ b/src/iDealAdvancedConnector/Connector.cs
@@ -322,7 +322,7 @@ namespace iDealAdvancedConnector
 
             // Serialize the request to an XML string
             string xmlRequest = SerializationHelper.SerializeObject<AcquirerStatusReq>(request);
-
+            
             var xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(xmlRequest);
 
@@ -473,13 +473,11 @@ namespace iDealAdvancedConnector
             {
                 using (XmlReader reader = XmlReader.Create(rdr, settings))
                 {
-                    xmlDoc.Load(reader);
+                    xmlDoc.Load(reader); 
+                    xmlDoc.Schemas.Add(XsdValidation.AllSchemas);
+                    xmlDoc.Validate(this.ValidationError);
                 }
             }
-
-            xmlDoc.Schemas.Add(XsdValidation.AllSchemas);
-
-            xmlDoc.Validate(this.ValidationError);
 
             // Check validation error list
             if (validationErrors.Count > 0)

--- a/src/iDealAdvancedConnector/Connector.cs
+++ b/src/iDealAdvancedConnector/Connector.cs
@@ -474,7 +474,7 @@ namespace iDealAdvancedConnector
                 using (XmlReader reader = XmlReader.Create(rdr, settings))
                 {
                     xmlDoc.Load(reader); 
-                    xmlDoc.Schemas.Add(XsdValidation.AllSchemas);
+                    xmlDoc.Schemas = XsdValidation.CreateXmlSchemaSet();
                     xmlDoc.Validate(this.ValidationError);
                 }
             }

--- a/src/iDealAdvancedConnector/Connector.cs
+++ b/src/iDealAdvancedConnector/Connector.cs
@@ -165,14 +165,16 @@ namespace iDealAdvancedConnector
 
             xmlRequest = xmlDoc.OuterXml;
 
+            var xmlSchemaSet = XsdValidation.CreateXmlSchemaSet();
+
             // Validate the request before sending it to the service
-            ValidateXML(xmlRequest);
+            ValidateXML(xmlRequest, xmlSchemaSet);
 
             // Send request / get respons
             string xmlResponse = await GetReplyFromAcquirer(xmlRequest, merchantConfig.acquirerUrlDIR);
 
             // Validate respons
-            ValidateXML(xmlResponse);
+            ValidateXML(xmlResponse, xmlSchemaSet);
 
             if (!XmlSignature.XmlSignature.CheckSignature(xmlResponse, (RSA)merchantConfig.aquirerCertificate.PublicKey.Key))
             {
@@ -252,14 +254,16 @@ namespace iDealAdvancedConnector
 
             xmlRequest = xmlDoc.OuterXml;
 
+            var xmlSchemaSet = XsdValidation.CreateXmlSchemaSet();
+
             // Validate the request before sending it to the service
-            ValidateXML(xmlRequest);
+            ValidateXML(xmlRequest, xmlSchemaSet);
 
             // Send request / get respons
             string xmlRespons = await GetReplyFromAcquirer(xmlRequest, merchantConfig.acquirerUrlTRA);
 
             // Validate respons
-            ValidateXML(xmlRespons);
+            ValidateXML(xmlRespons, xmlSchemaSet);
 
             if (!XmlSignature.XmlSignature.CheckSignature(xmlRespons, (RSA)merchantConfig.aquirerCertificate.PublicKey.Key))
             {
@@ -330,14 +334,16 @@ namespace iDealAdvancedConnector
 
             xmlRequest = xmlDoc.OuterXml;
 
+            var xmlSchemaSet = XsdValidation.CreateXmlSchemaSet();
+
             // Validate the request before sending it to the service
-            ValidateXML(xmlRequest);
+            ValidateXML(xmlRequest, xmlSchemaSet);
 
             // Send request / get respons
             string xmlResponse = await GetReplyFromAcquirer(xmlRequest, merchantConfig.acquirerUrlSTA);
 
             // Validate respons
-            ValidateXML(xmlResponse);
+            ValidateXML(xmlResponse, xmlSchemaSet);
 
             if (!XmlSignature.XmlSignature.CheckSignature(xmlResponse, (RSA)merchantConfig.aquirerCertificate.PublicKey.Key))
             {
@@ -456,7 +462,7 @@ namespace iDealAdvancedConnector
         /// </summary>
         /// <param name="xml">Xml to validate.</param>
         /// <exception cref="XmlSchemaValidationException">Schema validation error.</exception>
-        private void ValidateXML(string xml)
+        private void ValidateXML(string xml, XmlSchemaSet mlSchemaSet)
         {
             // Reset validation error list
             validationErrors = new List<string>();
@@ -474,7 +480,7 @@ namespace iDealAdvancedConnector
                 using (XmlReader reader = XmlReader.Create(rdr, settings))
                 {
                     xmlDoc.Load(reader); 
-                    xmlDoc.Schemas = XsdValidation.CreateXmlSchemaSet();
+                    xmlDoc.Schemas = mlSchemaSet;
                     xmlDoc.Validate(this.ValidationError);
                 }
             }

--- a/src/iDealAdvancedConnector/Security/XsdValidation.cs
+++ b/src/iDealAdvancedConnector/Security/XsdValidation.cs
@@ -17,16 +17,13 @@ namespace iDealAdvancedConnector.Security
     /// </summary>
     class XsdValidation
     {
-        static XmlSchemaSet allSchemas;
-        static readonly String Namespace = "iDealAdvancedConnector.Messages.";
-
         /// <summary>
-        /// Static ctor
+        /// Returns a collection of schemas
         /// </summary>
-        static XsdValidation()
-        {
-            allSchemas = GetXsdSet(new[] { "itt-acq.xsd", "xmldsigcore-schema.xsd" });
-        }
+        /// <returns></returns>
+        public static XmlSchemaSet CreateXmlSchemaSet() => GetXsdSet(new[] { "itt-acq.xsd", "xmldsigcore-schema.xsd" });
+        
+        static readonly String Namespace = "iDealAdvancedConnector.Messages.";
 
         /// <summary>
         /// Gets xsd file from disk
@@ -34,7 +31,7 @@ namespace iDealAdvancedConnector.Security
         /// <param name="xsdFileName"></param>
         /// <returns></returns>
         static XmlReader GetXsdFile(string xsdFileName)
-        {          
+        {
             var assembly = Assembly.GetAssembly(typeof(Connector));
             var stream = assembly.GetManifestResourceStream(Namespace + xsdFileName);
 
@@ -62,17 +59,6 @@ namespace iDealAdvancedConnector.Security
                 xsd.Add(schema);
             });
             return xsd;
-        }
-
-        /// <summary>
-        /// Returns a collection of schemas
-        /// </summary>
-        public static XmlSchemaSet AllSchemas
-        {
-            get
-            {
-                return allSchemas;
-            }
         }
     }
 }


### PR DESCRIPTION
`XmlSchemaSet` should not be shared among multiple threads for validation, as otherwise validation might fail.

Reproduced by having multiple concurrent request call `RequestTransactionStatus` and see that some of them fail with validation error.