### PR TITLE
Compile XmlSchemaSet

### DIFF
--- a/src/iDealAdvancedConnector/Security/XsdValidation.cs
+++ b/src/iDealAdvancedConnector/Security/XsdValidation.cs
@@ -65,7 +65,7 @@ namespace iDealAdvancedConnector.Security
             // Compilation of XmlSchemaSet is not thread safe, so we need to cache it in the compiled state,
             // to prevent it being compiled by multiple threads in parallel during validation.
 
-            // According to MSDN (https://docs.microsoft.com/de-de/dotnet/api/system.xml.schema.xmlschemaset.compile):
+            // According to MSDN (http://docs.microsoft.com/dotnet/api/system.xml.schema.xmlschemaset.compile?view=netstandard-2.0):
             // 1. Compile is called automatically when validation is needed and the XmlSchemaSet has not been previously compiled
             // 2. If the XmlSchemaSet is already in the compiled state, this method will not recompile the schemas
 

--- a/src/iDealAdvancedConnector/Security/XsdValidation.cs
+++ b/src/iDealAdvancedConnector/Security/XsdValidation.cs
@@ -62,7 +62,13 @@ namespace iDealAdvancedConnector.Security
                 xsd.Add(schema);
             });
 
-            // compile xml schema set, to prevent the compilation is called again
+            // Compilation of XmlSchemaSet is not thread safe, so we need to cache it in the compiled state,
+            // to prevent it being compiled by multiple threads in parallel during validation.
+
+            // According to MSDN (https://docs.microsoft.com/de-de/dotnet/api/system.xml.schema.xmlschemaset.compile):
+            // 1. Compile is called automatically when validation is needed and the XmlSchemaSet has not been previously compiled
+            // 2. If the XmlSchemaSet is already in the compiled state, this method will not recompile the schemas
+
             xsd.Compile();
             return xsd;
         }

--- a/src/iDealAdvancedConnector/Security/XsdValidation.cs
+++ b/src/iDealAdvancedConnector/Security/XsdValidation.cs
@@ -61,6 +61,9 @@ namespace iDealAdvancedConnector.Security
                 var schema = XmlSchema.Read(GetXsdFile(s), delegate { });
                 xsd.Add(schema);
             });
+
+            // compile xml schema set, to prevent the compilation is called again
+            xsd.Compile();
             return xsd;
         }
 


### PR DESCRIPTION
Pre-compile XmlSchemaSet, to make sure that parallel threads won't modify it by compiling it in parallel.