### PR TITLE
rebase with parent for iDEAL 2.0 upgrade

### DIFF
--- a/iDealAdvancedConnector/XmlSignature/XmlSignature.cs
+++ b/iDealAdvancedConnector/XmlSignature/XmlSignature.cs
@@ -97,12 +97,6 @@ namespace ING.iDealAdvanced.XmlSignature
             // Append the element to the XML document.
             doc.DocumentElement.AppendChild(doc.ImportNode(xmlSignature, true));
 
-            //xmlSignature.Prefix = "ds";
-            if (doc.FirstChild is XmlDeclaration)
-            {
-                doc.RemoveChild(doc.FirstChild);
-            }
-
             string xml = doc.OuterXml;
 
             //replace KeyValue with KeyName containing the fingerprint of the signing certificate


### PR DESCRIPTION
**Ideal 2.0** upgrade requires a change in the .net connector code 

Refer page 9 of migration [documentation ](https://www.ing.nl/media/iDEAL%20Migration%20Manual%20Step%20by%20Step_tcm162-236314.pdf)

**Important adjustment in the .NET connector
The current version of the .NET software contains code that generates XML. This is rejected in the
new platform. The XML message lacks the following line:**
`<?xml version="1.0" encoding="UTF-8"?>` According to the iDEAL standard, every message must start
with this line.
The .NET software has been updated accordingly. The new software can be downloaded from
ing.nl/idealupgrade. The software package for .NET contains the modified code. Specifically, the
component ‘XmlSignature.cs’ has been modified accordingly. The adjustment is that the code which does
not create the ‘prolog’ has been removed. You can also change this code yourself. In that case, you
remove the `‘XmlSignature.cs’` that is stated in red.
```
// Append the element to the XML document.
 doc.DocumentElement.AppendChild(doc.ImportNode(xmlSignature, true));

 //xmlSignature.Prefix = "ds";
 if (doc.FirstChild is XmlDeclaration)
 {
 doc.RemoveChild(doc.FirstChild);
 }

 string xml = doc.OuterXml;
```
